### PR TITLE
Fix ability to scroll after removing modal and removing ads leaderboard

### DIFF
--- a/scripts/contentScripts/adRemover.js
+++ b/scripts/contentScripts/adRemover.js
@@ -12,7 +12,7 @@ const callback = function (mutationsList) {
             removeAdContainers();
             pressPlay();
             muteVideoAds();
-
+            removeLeaderboard();
         }
     }
 };
@@ -44,6 +44,10 @@ const hideAdModals = () => {
     document.body.className = document.body.className.replace("modal-open","");
     hideItems([...adModals, ...adModalsBackDrop]);
     console.log("removed an ad");
+}
+const removeLeaderboard = () => {
+    var leaderboard = document.querySelector('.player-leaderboard');
+    leaderboard.parentNode.removeChild(leaderboard);
 }
 const pressPlay = () => {
     const playButton = document.querySelector(".play-pause-cont");

--- a/scripts/contentScripts/adRemover.js
+++ b/scripts/contentScripts/adRemover.js
@@ -41,6 +41,7 @@ const muteVideoAds = () => {
 const hideAdModals = () => {
     const adModals = document.querySelectorAll("ngb-modal-window");
     const adModalsBackDrop = document.querySelectorAll("ngb-modal-backdrop");
+    document.body.className = document.body.className.replace("modal-open","");
     hideItems([...adModals, ...adModalsBackDrop]);
     console.log("removed an ad");
 }


### PR DESCRIPTION
I removed a CSS class from body tag that happens to remain in the DOM after removing the advertisement modal, causing inability to scroll anywhere on the web player. Also I removed the ads leaderboard that's keep showing just right above the player controls.